### PR TITLE
Allow for the container's disk to live in BTRFS storage

### DIFF
--- a/lxc/nginx-proxy-manager/create.sh
+++ b/lxc/nginx-proxy-manager/create.sh
@@ -142,7 +142,7 @@ pveam download $_storage_template $_template &>/dev/null \
 # Create variables for container disk
 _storage_type=$(pvesm status -storage $_storage 2>/dev/null | awk 'NR>1 {print $2}')
 case $_storage_type in
-  dir|nfs)
+  btrfs|dir|nfs)
     _disk_ext=".raw"
     _disk_ref="$_ctid/"
     ;;


### PR DESCRIPTION
Per [the Proxmox docs](https://pve.proxmox.com/pve-docs/pvesm.1.html#storage_btrfs), "this storage type is very similar to the directory storage type, so see the directory backend section for a general overview".

Indeed, treating it the same as `dir` works perfectly. You end up with the following volume:

![01](https://user-images.githubusercontent.com/16709/157670030-90b1a417-d693-4ad5-bd35-87f6566d8859.png)

